### PR TITLE
Updated Kotlin to 2.1.0

### DIFF
--- a/app/compose/build.gradle.kts
+++ b/app/compose/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 }
 
 kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xwhen-guards")
+    }
+
     androidTarget {
         compilations.configureEach {
             compileTaskProvider.configure {

--- a/app/compose/build.gradle.kts
+++ b/app/compose/build.gradle.kts
@@ -77,7 +77,10 @@ android {
         }
     }
 
-    compileOptions.targetCompatibility = JavaVersion.toVersion(libs.versions.android.jvm.get())
+    compileOptions{
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.android.jvm.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.android.jvm.get())
+    }
 
     packaging.resources {
         excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/dynamic-price/android/build.gradle.kts
+++ b/dynamic-price/android/build.gradle.kts
@@ -58,7 +58,10 @@ android {
         }
     }
 
-    compileOptions.targetCompatibility = JavaVersion.toVersion(libs.versions.android.jvm.get())
+    compileOptions {
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.android.jvm.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.android.jvm.get())
+    }
 
     packaging.resources {
         excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/dynamic-price/android/build.gradle.kts
+++ b/dynamic-price/android/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
 }
 
 kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xwhen-guards")
+    }
+
     androidTarget {
         compilations.configureEach {
             compileTaskProvider.configure {

--- a/dynamic-price/android/build.gradle.kts
+++ b/dynamic-price/android/build.gradle.kts
@@ -54,6 +54,7 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "r8-rules.pro")
         }
     }
 

--- a/dynamic-price/android/r8-rules.pro
+++ b/dynamic-price/android/r8-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.google.android.tv.**

--- a/dynamic-price/android/src/androidMain/AndroidManifest.xml
+++ b/dynamic-price/android/src/androidMain/AndroidManifest.xml
@@ -44,7 +44,7 @@
             tools:node="merge">
             <!-- This entry makes AdsInitializer discoverable. -->
             <meta-data
-                android:name="${applicationId}.AdInitializer"
+                android:name="adsbynimbus.solutions.dynamicprice.app.AdInitializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,9 @@ kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx2g -XX:+UseParallelGC -Dfile.encoding=UTF-8
 kotlin.incremental.multiplatform=true
 kotlin.incremental.native=true
-kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
+kotlin.kmp.isolated-projects.support=enable
 kotlin.mpp.enableCInteropCommonization=true
+kotlin.native.enableKlibsCrossCompilation=true
 
 # iOS
 xcodeproj=app/ios/ios.xcodeproj

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ compose = "1.7.5"
 compose-activity = "1.9.3"
 compose-multiplatform = "1.7.1"
 
-kotlin = "2.0.21"
+kotlin = "2.1.0"
 kotlin-coroutines = "1.9.0"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ads-amazon = "9.10.3"
 ads-google = "23.5.0"
-ads-nimbus = "2.24.0"
+ads-nimbus = "2.24.1"
 
 android = "8.7.2"
 android-jvm = "17"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Changes

- Enabled Gradle isolated project checks
- Enabled klib compilation from any host
- Enabled when with guards
- Fixed R8 error with Nimbus 2.24.1
- Fixed Android Lint Warnings
- Removed deprecated Android Gradle Plugin warning

## Updates

- Gradle: 8.11.1
- Kotlin: 2.1.0
- Nimbus: 2.24.1