### PR TITLE
Build update and Dynamic Price app fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs
 
 | Platform                                       | Supported Languages | Latest Version                                                                                                                       |
 |------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.23.0-blue)                                                                        |
+| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.27.0-blue)                                                                        |
 | [iOS](/../../../../adsbynimbus/nimbus-ios-sdk) | Swift               | [![iOS](https://img.shields.io/github/v/release/adsbynimbus/nimbus-ios-sdk)](https://github.com/adsbynimbus/nimbus-ios-sdk/releases) |
 | [Unity](/../../../../adsbynimbus/nimbus-unity) | C#                  | [![OpenRTB](https://img.shields.io/github/v/release/adsbynimbus/nimbus-unity)](https://github.com/adsbynimbus/nimbus-unity/releases) |
 []()

--- a/dynamicprice/android/build.gradle.kts
+++ b/dynamicprice/android/build.gradle.kts
@@ -31,7 +31,7 @@ android {
     compileSdk = libs.versions.android.sdk.get().toInt()
 
     defaultConfig {
-        applicationId = "adsbynimbus.solutions.dynamicprice.app".also { namespace = it }
+        applicationId = "adsbynimbus.solutions.dynamicprice".also { namespace = it }
         minSdk = libs.versions.android.min.get().toInt()
         targetSdk = libs.versions.android.sdk.get().toInt()
         versionCode = 1

--- a/dynamicprice/android/src/androidMain/AndroidManifest.xml
+++ b/dynamicprice/android/src/androidMain/AndroidManifest.xml
@@ -37,7 +37,7 @@
             tools:node="merge">
             <!-- This entry makes AdsInitializer discoverable. -->
             <meta-data
-                android:name="adsbynimbus.solutions.dynamicprice.app.AdInitializer"
+                android:name="adsbynimbus.solutions.dynamicprice.AdInitializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/dynamicprice/android/src/androidMain/kotlin/AdInitializer.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/AdInitializer.kt
@@ -1,4 +1,4 @@
-package adsbynimbus.solutions.dynamicprice.app
+package adsbynimbus.solutions.dynamicprice
 
 import android.content.Context
 import android.util.Log

--- a/dynamicprice/android/src/androidMain/kotlin/AdLoader.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/AdLoader.kt
@@ -1,4 +1,4 @@
-package adsbynimbus.solutions.dynamicprice.app
+package adsbynimbus.solutions.dynamicprice
 
 import android.content.Context
 import android.util.Log

--- a/dynamicprice/android/src/androidMain/kotlin/AsyncUtils.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/AsyncUtils.kt
@@ -1,4 +1,4 @@
-package adsbynimbus.solutions.dynamicprice.app
+package adsbynimbus.solutions.dynamicprice
 
 import android.graphics.Rect
 import android.view.View

--- a/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
@@ -1,4 +1,4 @@
-package adsbynimbus.solutions.dynamicprice.app
+package adsbynimbus.solutions.dynamicprice
 
 import com.adsbynimbus.NimbusAdManager
 import com.adsbynimbus.lineitem.DEFAULT_BANNER

--- a/dynamicprice/android/src/androidMain/kotlin/MainActivity.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/MainActivity.kt
@@ -1,4 +1,4 @@
-package adsbynimbus.solutions.dynamicprice.app
+package adsbynimbus.solutions.dynamicprice
 
 import android.os.Bundle
 import android.util.Log

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
 ads-amazon = "10.1.0"
 ads-google = "24.0.0"
-ads-nimbus = "2.26.1"
+ads-nimbus = "2.27.0"
 
-android = "8.8.2"
-android-jvm = "17"
+android = "8.9.0"
+android-jvm = "19"
 android-min = "26"
-android-sdk = "35"
+android-sdk = "36"
 
-androidx-collection = "1.4.5"
+androidx-collection = "1.5.0"
 androidx-lifecycle = "2.8.7"
-androidx-navigation = "2.8.8"
+androidx-navigation = "2.8.9"
 androidx-startup = "1.2.0"
 
 compose = "1.7.8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ads-amazon = "10.1.0"
-ads-google = "24.0.0"
+ads-google = "23.6.0"
 ads-nimbus = "2.27.0"
 
 android = "8.9.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 val isFleetIDE = providers.systemProperty("idea.vendor.name").filter { it == "JetBrains" }
-val androidGradleOverride = isFleetIDE.map { "8.7.2" }
+val androidGradleOverride = isFleetIDE.map { "8.7.3" }
     .orElse(providers.gradleProperty("android.gradle"))
 val androidJvmOverride = providers.gradleProperty("android.jvm")
 


### PR DESCRIPTION
## Updated Tooling and Libraries

- Android Gradle Plugin: 8.9.0
- Android JVM: 19
- Android Compile SDK: 36
- Androidx Collection: 1.5.0
- Androidx Navigation: 2.8.9
- Nimbus: 2.27.0

## Fixed runtime crash in Dynamic Price app

#### Downgraded Google Mobile Ads to 23.6.0

The update to Google Mobile Ads 24.0.0 causes a runtime crash due to the `addCustomTargeting` method moving to a super class of `AdManagerAdRequest.Builder`, the Nimbus SDK and the Amazon SDK both attempt to resolve the method from the old location and will crash at runtime.

## Other

- Removed .app from Dynamic Price app to re-enable ad serving
- Updated Fleet Android Gradle Plugin version to 8.7.3
- Updated Nimbus Android SDK version in README to 2.27.0