### PR TITLE
Updated Google Mobile Ads to 24.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs
 
 | Platform                                       | Supported Languages | Latest Version                                                                                                                       |
 |------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.27.0-blue)                                                                        |
+| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.28.2-blue)                                                                        |
 | [iOS](/../../../../adsbynimbus/nimbus-ios-sdk) | Swift               | [![iOS](https://img.shields.io/github/v/release/adsbynimbus/nimbus-ios-sdk)](https://github.com/adsbynimbus/nimbus-ios-sdk/releases) |
 | [Unity](/../../../../adsbynimbus/nimbus-unity) | C#                  | [![OpenRTB](https://img.shields.io/github/v/release/adsbynimbus/nimbus-unity)](https://github.com/adsbynimbus/nimbus-unity/releases) |
 []()

--- a/dynamicprice/README.md
+++ b/dynamicprice/README.md
@@ -1,0 +1,55 @@
+# Dynamic Price
+
+Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs/extended-documentation/dynamic-price](https://docs.adsbynimbus.com/docs/extended-documentation/dynamic-price)
+
+## Android
+
+An implementation showing how to run requests to Nimbus and Amazon in parallel when both
+bidders are used with Google Ad Manager.
+
+#### [Bidders](android/src/androidMain/kotlin/Bidders.kt)
+
+Contains classes and interfaces for running a parallel auction using any number of bidders and
+applying the key-value targeting from each bid to an `AdManagerAdRequest.Builder`.
+
+#### [DynamicPriceAd](android/src/androidMain/kotlin/DynamicPriceAd.kt)
+
+Provides a wrapper implementation for the `AdManagerAdView` that automatically manages the bidding
+process and refreshes ads every 30 seconds using a lifecycleScope.
+
+### Google Mobile Ads 24
+
+[Migration Guide](https://developers.google.com/ad-manager/mobile-ads-sdk/android/migration#migrate-to-v24)
+
+Current versions of Nimbus and Amazon SDKs were compiled against Google Mobile Ads 23 and will crash
+at runtime when used with version 24 or higher due to the `addCustomTargeting` method moving from
+the `AdManagerAdRequest.Builder` to the super class `AbstractAdRequestBuilder<*>`.
+
+A workaround for this has been implemented for both SDKs in [Bidders.applyTargeting](android/src/androidMain/kotlin/Bidders.kt#L63).
+
+###### Nimbus
+```kotlin
+when (response) {
+    is NimbusResponse -> response.run {
+        dynamicPriceAdCache.put(auctionId, this)
+        targetingMap(linearPriceMapping).forEach {
+            request.addCustomTargeting(it.key, it.value)
+        }
+    }
+}
+```
+
+###### Amazon
+```kotlin
+inline val DTBAdResponse.adManagerParams: Map<String, List<String>>
+    get() = when (dtbAds.first().dtbAdType) {
+        AdType.VIDEO -> defaultVideoAdsRequestCustomParams.mapValues { listOf(it.value) }
+        else -> defaultDisplayAdsRequestCustomParams
+    }
+
+when (response) {
+    is DTBAdResponse if response.adCount > 0 -> response.adManagerParams.forEach {
+        request.addCustomTargeting(it.key, it.value)
+    }
+}
+```

--- a/dynamicprice/android/src/androidMain/kotlin/AdInitializer.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/AdInitializer.kt
@@ -13,7 +13,7 @@ import kotlin.time.measureTime
 @Suppress("unused")
 class AdInitializer : Initializer<Map<String, DynamicPriceAd>> {
     override fun create(context: Context): Map<String, DynamicPriceAd> {
-        // Set appContext in AdLoader.kt to use for preloading ads
+        // Set appContext in DynamicPriceAd.kt to use for preloading ads
         appContext = context
         val nimbusStartup = measureTime {
             Nimbus.initialize(context, BuildConfig.PUBLISHER_KEY, BuildConfig.API_KEY)

--- a/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
@@ -48,7 +48,7 @@ val linearPriceMapping = DEFAULT_BANNER
 /** Loads a bid from Nimbus using the global NimbusAdManager instance */
 @JvmInline
 value class NimbusBidder(private val adRequest: NimbusRequest) : Bidder<NimbusResponse> {
-    // appContext is defined in AdLoader.kt and set in the AdInitializer
+    // appContext is defined in DynamicPriceAd.kt and set in the AdInitializer
     override suspend fun fetchBid(): Bid<NimbusResponse> =
         Bid(nimbusAdManager.makeRequest(appContext, adRequest))
 }

--- a/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
@@ -1,13 +1,14 @@
 package adsbynimbus.solutions.dynamicprice
 
 import com.adsbynimbus.NimbusAdManager
+import com.adsbynimbus.google.dynamicPriceAdCache
 import com.adsbynimbus.lineitem.DEFAULT_BANNER
-import com.adsbynimbus.lineitem.applyDynamicPrice
+import com.adsbynimbus.lineitem.targetingMap
 import com.adsbynimbus.request.NimbusRequest
 import com.adsbynimbus.request.NimbusResponse
+import com.amazon.device.ads.AdType
 import com.amazon.device.ads.DTBAdRequest
 import com.amazon.device.ads.DTBAdResponse
-import com.amazon.device.ads.DTBAdUtil
 import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
@@ -61,7 +62,20 @@ value class ApsBidder(private val adRequest: () -> DTBAdRequest) : Bidder<DTBAdR
 /** Applies targeting values from a Bid to an AdManagerAdRequest.Builder */
 inline fun <reified T> Bid<out T>.applyTargeting(request: AdManagerAdRequest.Builder) {
     when (response) {
-        is NimbusResponse -> response.applyDynamicPrice(request, linearPriceMapping)
-        is DTBAdResponse -> DTBAdUtil.INSTANCE.loadDTBParams(request, response)
+        is NimbusResponse -> response.run {
+            dynamicPriceAdCache.put(auctionId, this)
+            targetingMap(linearPriceMapping).forEach {
+                request.addCustomTargeting(it.key, it.value)
+            }
+        }
+        is DTBAdResponse if response.adCount > 0 -> response.adManagerParams.forEach {
+            request.addCustomTargeting(it.key, it.value)
+        }
     }
 }
+
+inline val DTBAdResponse.adManagerParams: Map<String, List<String>>
+    get() = when (dtbAds.first().dtbAdType) {
+        AdType.VIDEO -> defaultVideoAdsRequestCustomParams.mapValues { listOf(it.value) }
+        else -> defaultDisplayAdsRequestCustomParams
+    }

--- a/dynamicprice/android/src/androidMain/kotlin/MainActivity.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/MainActivity.kt
@@ -16,7 +16,7 @@ class MainActivity : ComponentActivity() {
             val preloadBanner = adCache["banner"] ?: return
             val startTime = Monotonic.markNow()
             // Must set the listener before attaching to the parent view
-            preloadBanner.adView.adListener = object : AdListener() {
+            preloadBanner.view.adListener = object : AdListener() {
                 override fun onAdLoaded() {
                     Log.i("Ads", "Loaded: ${Monotonic.markNow() - startTime}")
                 }
@@ -29,7 +29,7 @@ class MainActivity : ComponentActivity() {
                     Log.w("Ads", "Failed: ${p0.message}")
                 }
             }
-            addView(preloadBanner.adView)
+            addView(preloadBanner.view)
         })
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ads-amazon = "10.1.0"
-ads-google = "23.6.0"
-ads-nimbus = "2.27.0"
+ads-google = "24.1.0"
+ads-nimbus = "2.28.2"
 
 android = "8.9.0"
 android-jvm = "19"


### PR DESCRIPTION
Current versions of Nimbus and Amazon SDKs were compiled against Google Mobile Ads 23 and will crash
at runtime when used with version 24 or higher due to the `addCustomTargeting` method moving from
the `AdManagerAdRequest.Builder` to the super class `AbstractAdRequestBuilder<*>`.

A workaround for this has been implemented for both SDKs in [Bidders.applyTargeting](android/src/androidMain/kotlin/Bidders.kt#L63) and requires updating Nimbus to 2.28.2 or higher.

##### Nimbus
```kotlin
when (response) {
    is NimbusResponse -> response.run {
        dynamicPriceAdCache.put(auctionId, this)
        targetingMap(linearPriceMapping).forEach {
            request.addCustomTargeting(it.key, it.value)
        }
    }
}
```

##### Amazon
```kotlin
inline val DTBAdResponse.adManagerParams: Map<String, List<String>>
    get() = when (dtbAds.first().dtbAdType) {
        AdType.VIDEO -> defaultVideoAdsRequestCustomParams.mapValues { listOf(it.value) }
        else -> defaultDisplayAdsRequestCustomParams
    }

when (response) {
    is DTBAdResponse if response.adCount > 0 -> response.adManagerParams.forEach {
        request.addCustomTargeting(it.key, it.value)
    }
}
```
