### PR TITLE
Ad Libraries and Compose 1.8.0 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs
 
 | Platform                                       | Supported Languages | Latest Version                                                                                                                       |
 |------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.28.2-blue)                                                                        |
+| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.29.0-blue)                                                                        |
 | [iOS](/../../../../adsbynimbus/nimbus-ios-sdk) | Swift               | [![iOS](https://img.shields.io/github/v/release/adsbynimbus/nimbus-ios-sdk)](https://github.com/adsbynimbus/nimbus-ios-sdk/releases) |
 | [Unity](/../../../../adsbynimbus/nimbus-unity) | C#                  | [![OpenRTB](https://img.shields.io/github/v/release/adsbynimbus/nimbus-unity)](https://github.com/adsbynimbus/nimbus-unity/releases) |
 []()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ads-amazon = "10.1.1"
+ads-amazon = "11.0.0"
 ads-google = "24.2.0"
 ads-google-nextgen = "0.14.0-alpha01"
 ads-nimbus = "2.29.0"
@@ -9,6 +9,7 @@ android-jvm = "19"
 android-min = "26"
 android-sdk = "36"
 
+androidx-appcompat = "1.7.0"
 androidx-collection = "1.5.0"
 androidx-lifecycle = "2.8.7"
 androidx-navigation = "2.8.9"
@@ -40,6 +41,7 @@ ads-google = { module = "com.google.android.gms:play-services-ads", version.ref 
 ads-google-nextgen = { module = "com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk", version.ref = "ads-google-nextgen" }
 ads-nimbus = { module = "com.adsbynimbus.android:nimbus", version.ref = "ads-nimbus" }
 ads-nimbus-google = { module = "com.adsbynimbus.android:extension-google", version.ref = "ads-nimbus" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 androidx-lifecycle = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
@@ -62,5 +64,19 @@ androidx-compose = [
     "compose-ui-tooling",
     "compose-ui-tooling-preview",
 ]
-dynamicprice = ["ads-amazon", "ads-google", "ads-nimbus", "ads-nimbus-google"]
-dynamicprice-nextgen = ["ads-amazon", "ads-google-nextgen", "ads-nimbus", "gson", "okhttp", "okio"]
+dynamicprice = [
+    "ads-amazon",
+    "ads-google",
+    "ads-nimbus",
+    "ads-nimbus-google",
+    "androidx-appcompat", # Referenced by Amazon but not included in build
+]
+dynamicprice-nextgen = [
+    "ads-amazon",
+    "ads-google-nextgen",
+    "ads-nimbus",
+    "androidx-appcompat", # Referenced by Amazon but not included in build
+    "gson",
+    "okhttp",
+    "okio",
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ ads-google = "24.2.0"
 ads-google-nextgen = "0.15.0-alpha01" # 0.15.1 Requires API Desugaring
 ads-nimbus = "2.29.0"
 
-android = "8.9.1"
+android = "8.10.0"
 android-jvm = "19"
 android-min = "26"
 android-sdk = "36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,9 @@ androidx-lifecycle = "2.8.7"
 androidx-navigation = "2.8.9"
 androidx-startup = "1.2.0"
 
-compose = "1.7.8"
+compose = "1.8.0"
 compose-activity = "1.10.1"
-compose-multiplatform = "1.7.3"
+compose-multiplatform = "1.8.0"
 
 gson = "2.13.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 ads-amazon = "10.1.1"
 ads-google = "24.2.0"
 ads-google-nextgen = "0.14.0-alpha01"
-ads-nimbus = "2.28.2"
+ads-nimbus = "2.29.0"
 
 android = "8.9.1"
 android-jvm = "19"
@@ -40,7 +40,6 @@ ads-google = { module = "com.google.android.gms:play-services-ads", version.ref 
 ads-google-nextgen = { module = "com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk", version.ref = "ads-google-nextgen" }
 ads-nimbus = { module = "com.adsbynimbus.android:nimbus", version.ref = "ads-nimbus" }
 ads-nimbus-google = { module = "com.adsbynimbus.android:extension-google", version.ref = "ads-nimbus" }
-ads-nimbus-vast = { module = "com.adsbynimbus.android:nimbus-vast", version.ref = "ads-nimbus" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 androidx-lifecycle = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
@@ -55,7 +54,6 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 
 [bundles]
-ads-nimbus = ["ads-nimbus", "ads-nimbus-vast"]
 androidx = ["androidx-collection", "androidx-lifecycle", "androidx-startup"]
 androidx-compose = [
     "compose-activity",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ads-amazon = "11.0.0"
 ads-google = "24.2.0"
-ads-google-nextgen = "0.14.0-alpha01"
+ads-google-nextgen = "0.15.0-alpha01" # 0.15.1 Requires API Desugaring
 ads-nimbus = "2.29.0"
 
 android = "8.9.1"
@@ -19,7 +19,7 @@ compose = "1.7.8"
 compose-activity = "1.10.1"
 compose-multiplatform = "1.7.3"
 
-gson = "2.13.0"
+gson = "2.13.1"
 
 kotlin = "2.1.20"
 kotlin-coroutines = "1.10.2"

--- a/omsdk/android/build.gradle.kts
+++ b/omsdk/android/build.gradle.kts
@@ -24,9 +24,9 @@ kotlin {
             implementation(libs.kotlin.coroutines)
         }
         androidMain.dependencies {
+            implementation(libs.ads.nimbus)
             implementation(libs.bundles.androidx)
             implementation(libs.bundles.androidx.compose)
-            implementation(libs.bundles.ads.nimbus)
         }
     }
 }

--- a/omsdk/android/src/androidMain/kotlin/AppInitializer.kt
+++ b/omsdk/android/src/androidMain/kotlin/AppInitializer.kt
@@ -7,25 +7,16 @@ import androidx.startup.Initializer
 import com.adsbynimbus.IABVerificationProvider
 import com.adsbynimbus.Nimbus
 import com.adsbynimbus.ViewabilityProvider
-import com.adsbynimbus.render.Renderer
-import com.adsbynimbus.render.StaticAdRenderer
-import com.adsbynimbus.render.VastRenderer
-import com.adsbynimbus.request.OkHttpNimbusClient
 import kotlin.time.measureTime
 
 class AppInitializer : Initializer<Nimbus> {
     override fun create(context: Context): Nimbus = Nimbus.apply {
-        val videoRenderer = VastRenderer()
         val startupTime = measureTime {
-            initialize(context, BuildConfig.PUBLISHER_KEY, BuildConfig.API_KEY, components =
-                setOf(OkHttpNimbusClient(), StaticAdRenderer(), videoRenderer)
-            )
+            initialize(context, BuildConfig.PUBLISHER_KEY, BuildConfig.API_KEY)
             testMode = true
             addLogger(Nimbus.Logger.Default(level = Log.VERBOSE))
         }
 
-        Renderer.INLINE.put("video", videoRenderer)
-        VastRenderer.showMuteButton = true
         ViewabilityProvider.verificationProviders.add(IABVerificationProvider)
 
         Log.i("Nimbus", "Startup Time: $startupTime")


### PR DESCRIPTION
## Changes

- Removed references to Nimbus Vast library; it is included in the Nimbus SDK by default now
- Added Androidx AppCompat to Dynamic Price apps to fix broken references from the Amazon SDK

## Updated Libraries

- Amazon Ads Android: 11.0.0
- Android Gradle Plugin: 8.10.0
- Androidx AppCompat: 1.7.0
- Compose: 1.8.0
- Compose Multiplatform: 1.8.0
- Google Next Gen: 0.15.0-alpha01
- Gson: 2.13.1
- Nimbus Android: 2.29.0