### PR TITLE
Nimbus Android 2.30.0 update; removed Google Ads 24 workaround 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs
 
 | Platform                                       | Supported Languages | Latest Version                                                                                                                       |
 |------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.29.1-blue)                                                                        |
+| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.30.0-blue)                                                                        |
 | [iOS](/../../../../adsbynimbus/nimbus-ios-sdk) | Swift               | [![iOS](https://img.shields.io/github/v/release/adsbynimbus/nimbus-ios-sdk)](https://github.com/adsbynimbus/nimbus-ios-sdk/releases) |
 | [Unity](/../../../../adsbynimbus/nimbus-unity) | C#                  | [![OpenRTB](https://img.shields.io/github/v/release/adsbynimbus/nimbus-unity)](https://github.com/adsbynimbus/nimbus-unity/releases) |
 []()

--- a/dynamicprice/README.md
+++ b/dynamicprice/README.md
@@ -21,13 +21,20 @@ process and refreshes ads every 30 seconds using a lifecycleScope.
 
 [Migration Guide](https://developers.google.com/ad-manager/mobile-ads-sdk/android/migration#migrate-to-v24)
 
-Current versions of Nimbus and Amazon SDKs were compiled against Google Mobile Ads 23 and will crash
-at runtime when used with version 24 or higher due to the `addCustomTargeting` method moving from
-the `AdManagerAdRequest.Builder` to the super class `AbstractAdRequestBuilder<*>`.
+Support for Google Mobile Ads 24 is available starting from the following versions:
 
-A workaround for this has been implemented for both SDKs in [Bidders.applyTargeting](android/src/androidMain/kotlin/Bidders.kt#L63).
+- Nimbus Android: [2.30.0](https://docs.adsbynimbus.com/docs/sdk/android/changelog#id-2.30.0-5-13-25)
+- Amazon APS Android: [11.0.0](https://ams.amazon.com/webpublisher/uam/docs/aps-mobile/android/release-notes) (Link requires Login)
 
-###### Nimbus
+<details>
+<summary>Workaround for older SDK Versions</summary>
+<br/>
+Previous versions of the Nimbus and Amazon SDKs will crash at runtime when used with version 24 or
+higher due to the `addCustomTargeting` method moving from the `AdManagerAdRequest.Builder` to the
+super class `AbstractAdRequestBuilder<*>`.
+
+###### Nimbus - Requires 2.28.0 or higher
+Replace calls to `applyDynamicPrice` with it's method body
 ```kotlin
 when (response) {
     is NimbusResponse -> response.run {
@@ -40,7 +47,9 @@ when (response) {
 ```
 
 ###### Amazon
+Replace calls to `DTBAdUtil.INSTANCE.loadDTBParams` with it's method body
 ```kotlin
+/** Implementation of a private helper method used by loadDTBParams to retrieve kv pairs */
 inline val DTBAdResponse.adManagerParams: Map<String, List<String>>
     get() = when (dtbAds.first().dtbAdType) {
         AdType.VIDEO -> defaultVideoAdsRequestCustomParams.mapValues { listOf(it.value) }
@@ -53,6 +62,7 @@ when (response) {
     }
 }
 ```
+</details>
 
 ## iOS
 

--- a/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
@@ -5,9 +5,9 @@ import com.adsbynimbus.lineitem.DEFAULT_BANNER
 import com.adsbynimbus.lineitem.applyDynamicPrice
 import com.adsbynimbus.request.NimbusRequest
 import com.adsbynimbus.request.NimbusResponse
-import com.amazon.device.ads.AdType
 import com.amazon.device.ads.DTBAdRequest
 import com.amazon.device.ads.DTBAdResponse
+import com.amazon.device.ads.DTBAdUtil
 import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
@@ -62,14 +62,6 @@ value class ApsBidder(private val adRequest: () -> DTBAdRequest) : Bidder<DTBAdR
 inline fun <reified T> Bid<out T>.applyTargeting(request: AdManagerAdRequest.Builder) {
     when (response) {
         is NimbusResponse -> request.applyDynamicPrice(ad = response, mapping = linearPriceMapping)
-        is DTBAdResponse if response.adCount > 0 -> response.adManagerParams.forEach {
-            request.addCustomTargeting(it.key, it.value)
-        }
+        is DTBAdResponse -> DTBAdUtil.INSTANCE.loadDTBParams(request, response)
     }
 }
-
-inline val DTBAdResponse.adManagerParams: Map<String, List<String>>
-    get() = when (dtbAds.first().dtbAdType) {
-        AdType.VIDEO -> defaultVideoAdsRequestCustomParams.mapValues { listOf(it.value) }
-        else -> defaultDisplayAdsRequestCustomParams
-    }

--- a/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
+++ b/dynamicprice/android/src/androidMain/kotlin/Bidders.kt
@@ -1,9 +1,8 @@
 package adsbynimbus.solutions.dynamicprice
 
 import com.adsbynimbus.NimbusAdManager
-import com.adsbynimbus.google.dynamicPriceAdCache
 import com.adsbynimbus.lineitem.DEFAULT_BANNER
-import com.adsbynimbus.lineitem.targetingMap
+import com.adsbynimbus.lineitem.applyDynamicPrice
 import com.adsbynimbus.request.NimbusRequest
 import com.adsbynimbus.request.NimbusResponse
 import com.amazon.device.ads.AdType
@@ -62,12 +61,7 @@ value class ApsBidder(private val adRequest: () -> DTBAdRequest) : Bidder<DTBAdR
 /** Applies targeting values from a Bid to an AdManagerAdRequest.Builder */
 inline fun <reified T> Bid<out T>.applyTargeting(request: AdManagerAdRequest.Builder) {
     when (response) {
-        is NimbusResponse -> response.run {
-            dynamicPriceAdCache.put(auctionId, this)
-            targetingMap(linearPriceMapping).forEach {
-                request.addCustomTargeting(it.key, it.value)
-            }
-        }
+        is NimbusResponse -> request.applyDynamicPrice(ad = response, mapping = linearPriceMapping)
         is DTBAdResponse if response.adCount > 0 -> response.adManagerParams.forEach {
             request.addCustomTargeting(it.key, it.value)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 ads-amazon = "11.0.0"
 ads-google = "24.2.0"
 ads-google-nextgen = "0.15.0-alpha01" # 0.15.1 Requires API Desugaring
-ads-nimbus = "2.29.1"
+ads-nimbus = "2.30.0"
 
 android = "8.10.0"
 android-jvm = "19"


### PR DESCRIPTION
## Changes

- Revert Dynamic Price Google Mobile Ads 24 Workaround
  - Replaced Nimbus workaround with `applyDynamicPrice`
  - Replaced Amazon workaround with `DTBAdUtil.INSTANCE.loadDTBParams`

## Updated Libraries

- Nimbus Android: 2.30.0