### PR TITLE
Force APS SDK to 10.1.0 for Dynamic Price Nextgen to ensure ads serve

### DIFF
--- a/dynamicprice/nextgen/build.gradle.kts
+++ b/dynamicprice/nextgen/build.gradle.kts
@@ -28,6 +28,15 @@ kotlin {
     }
 }
 
+configurations.configureEach {
+    resolutionStrategy.eachDependency {
+        if (requested.module == libs.ads.amazon.get().module) {
+            useVersion("10.1.0")
+            because("11+ will not serve ads due to failed GMA 24+ check")
+        }
+    }
+}
+
 android {
     compileSdk = libs.versions.android.sdk.get().toInt()
 


### PR DESCRIPTION
Forces APS SDK to 10.1.0 to ensure APS serves ads on Dynamic Price Nextgen; APS 11+ will only serve ads if an internal check for Google Mobile Ads 24 SDK passes.