### PR TITLE
Updated Libraries: Amazon Ads 11.0.1 / 10.1.1, Google Mobile Ads 24.4.0

### DIFF
--- a/dynamicprice/nextgen/build.gradle.kts
+++ b/dynamicprice/nextgen/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 configurations.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.module == libs.ads.amazon.get().module) {
-            useVersion("10.1.0")
+            useVersion("10.1.1")
             because("11+ will not serve ads due to failed GMA 24+ check")
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-ads-amazon = "11.0.0"
-ads-google = "24.3.0"
+ads-amazon = "11.0.1"
+ads-google = "24.4.0"
 ads-google-nextgen = "0.16.0-alpha01"
 ads-nimbus = "2.30.0"
 


### PR DESCRIPTION
## Updated Libraries
- Amazon Ads: 11.0.1 (Dynamic Price) / 10.1.1 (Dynamic Price NextGen)
- Google Ads: 24.4.0