### PR TITLE
Fixed NextGen interstitial close behavior and simplified implementation

### DIFF
--- a/dynamicprice/nextgen/src/androidMain/kotlin/DynamicPrice.kt
+++ b/dynamicprice/nextgen/src/androidMain/kotlin/DynamicPrice.kt
@@ -9,14 +9,11 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.annotation.WorkerThread
 import androidx.collection.LruCache
+import androidx.core.os.BundleCompat.getSerializable
 import androidx.core.view.allViews
-import androidx.core.view.doOnAttach
-import androidx.lifecycle.findViewTreeLifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import com.adsbynimbus.NimbusAd
 import com.adsbynimbus.NimbusError
 import com.adsbynimbus.internal.Platform
-import com.adsbynimbus.internal.lifecycleOrNimbusScope
 import com.adsbynimbus.internal.log
 import com.adsbynimbus.lineitem.Mapping
 import com.adsbynimbus.lineitem.targetingMap
@@ -44,7 +41,7 @@ fun <T: BaseAdRequestBuilder<T>> BaseAdRequestBuilder<T>.applyDynamicPrice(
     nimbusAd: NimbusResponse,
     mapping: Mapping,
 ) {
-    nimbusAdCache.put(nimbusAd.auctionId, nimbusAd)
+    DynamicPriceRenderer.adCache.put(nimbusAd.auctionId, nimbusAd)
     nimbusAd.targetingMap(mapping).forEach { putCustomTargeting(it.key, it.value) }
 }
 
@@ -53,38 +50,17 @@ fun <T: BaseAdRequestBuilder<T>> BaseAdRequestBuilder<T>.applyDynamicPrice(
  *
  * @param name passed from onAppEvent
  * @param data passed from onAppEvent
- * @param eventListener optional listener for Nimbus Ad events and errors
+ * @param listener optional listener for Nimbus Ad events and errors
  * @param activity optional context the ad is loaded in; current activity used as the default
  */
 fun BannerAd.handleEventForNimbus(
     name: String,
     data: String?,
-    eventListener: AdController.Listener? = null,
+    listener: AdController.Listener? = null,
     activity: Activity? = Platform.currentActivity.get(),
 ) {
-    data?.takeIf { name == "na_render" }?.runCatching {
-        val event = jsonSerializer.decodeFromString<RenderEvent>(serializer(), this)
-        activity!!.lifecycleOrNimbusScope.launch(Dispatchers.Main.immediate) {
-            val adView = getView(activity)
-            val controller = event.nimbusAd.renderInline(
-                container = adView.allViews.filterIsInstance<WebView>().first().parent as ViewGroup
-            )
-            controller.attachListener(
-                googleClickTracker = event.clickTracker,
-                onClick = { adEventCallback?.onAdClicked() },
-                onDestroy = { destroy() }
-            )
-            eventListener?.let { controller.listeners.add(it) }
-            adView.doOnAttach {
-                adView.controllerJob = it.findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-                    try {
-                        awaitCancellation()
-                    } finally {
-                        controller.destroy()
-                    }
-                }
-            }
-        }
+    if (name == "na_render") DynamicPriceRenderer.render(this, data, listener) { nimbusAd ->
+        nimbusAd.renderInline(getView(activity!!).webViewParent)
     }
 }
 
@@ -93,89 +69,154 @@ fun BannerAd.handleEventForNimbus(
  *
  * @param name passed from onAppEvent
  * @param data passed from onAppEvent
- * @param eventListener optional listener for Nimbus Ad events and errors
+ * @param listener optional listener for Nimbus Ad events and errors
  * @param activity optional context the ad is loaded in; current activity used as the default
  */
 fun InterstitialAd.handleEventForNimbus(
     name: String,
     data: String?,
-    eventListener: AdController.Listener? = null,
+    listener: AdController.Listener? = null,
     activity: Activity? = Platform.currentActivity.get(),
 ) {
-    data?.takeIf { name == "na_render" }?.runCatching {
-        val event = jsonSerializer.decodeFromString<RenderEvent>(serializer(), this)
-        activity!!.runOnUiThread {
-            val controller = activity.loadBlockingAd(event.nimbusAd)!!
-            controller.attachListener(
-                googleClickTracker = event.clickTracker,
-                onClick = { adEventCallback?.onAdClicked() },
-                onDestroy = { activity.destroy() }
-            )
-            eventListener?.let { controller.listeners.add(it) }
-            controller.start()
+    when (name) {
+        "na_render" -> DynamicPriceRenderer.render(this, data, listener) { nimbusAd ->
+            activity!!.loadBlockingAd(nimbusAd)!!
         }
-    }?.onFailure {
-        adEventCallback?.onAdFailedToShowFullScreenContent(
-            FullScreenContentError(
-                code = MEDIATION_SHOW_ERROR,
-                message = "Nimbus Rendering Failure ${it.message}",
-                mediationAdError = null,
-            )
-        )
-        activity.takeIf { it is AdActivity }?.destroy()
+        "na_show" -> DynamicPriceRenderer.renderScope.launch(Dispatchers.Main) {
+            dynamicPriceAd?.adController?.start() ?: run {
+                adEventCallback?.onAdFailedToShowFullScreenContent(
+                    FullScreenContentError(
+                        code = MEDIATION_SHOW_ERROR,
+                        message = "Nimbus controller failed to show",
+                        mediationAdError = null,
+                    )
+                )
+                maybeClearInterstitial(activity)
+            }
+        }
     }
 }
 
-/** Searches all children for a Nimbus Ad job and cancels it, destroying the AdController */
-fun ViewGroup.destroyNimbusAds() = allViews.firstOrNull { it.controllerJob != null }?.let {
-    it.controllerJob?.cancel()
-    it.controllerJob = null
+@JvmInline
+value class DynamicPriceAd(val adController: AdController) : java.io.Serializable {
+    fun destroy() = adController.destroy()
 }
 
-/** Stores a BannerAd LifeCycle job using View tags */
-internal inline var View.controllerJob: Job?
-    get() = getTag(com.adsbynimbus.render.R.id.controller) as Job?
-    set(value) { setTag(com.adsbynimbus.render.R.id.controller, value) }
+inline var Ad.dynamicPriceAd: DynamicPriceAd?
+    get() = getSerializable(getResponseInfo().responseExtras, "na_render", DynamicPriceAd::class.java)
+    internal set(value) {
+        getResponseInfo().responseExtras.apply {
+            if (value == null) remove("na_render") else putSerializable("na_render", value)
+        }
+    }
+
+internal inline val View.webViewParent: ViewGroup
+    get() = allViews.filterIsInstance<WebView>().first().parent as ViewGroup
+
+internal fun maybeClearInterstitial(activity: Activity? = Platform.currentActivity.get()) {
+    when {
+        activity !is AdActivity -> return
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> activity.run {
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
+            finish()
+        }
+        else -> activity.run {
+            finish()
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
+        }
+    }
+}
+
 
 @Serializable
-internal data class RenderEvent(
+internal class DynamicPriceRenderer(
     @SerialName("na_id") val auctionId: String,
     @SerialName("ga_click") val clickTracker: String,
-)
-
-internal inline val RenderEvent.nimbusAd: NimbusAd
-    get() = nimbusAdCache[auctionId]!!
-
-internal inline fun AdController.attachListener(
-    googleClickTracker: String,
-    crossinline onClick: () -> Unit,
-    crossinline onDestroy: () -> Unit,
-) = listeners.add(object : AdController.Listener {
-
-    override fun onAdEvent(adEvent: AdEvent) {
-        when (adEvent) {
-            AdEvent.CLICKED -> {
-                CoroutineScope(Dispatchers.IO).launch {
-                    when (OneShotConnection(googleClickTracker).use { it.responseCode }) {
-                        in 200..399 -> log(Log.VERBOSE, "Fired Google click tracker")
-                        else -> log(Log.WARN, "Error firing Google click tracker")
+) {
+    companion object {
+        fun render(
+            ad: Ad,
+            data: String?,
+            publisherListener: AdController.Listener?,
+            render: suspend (NimbusAd) -> AdController,
+        ) {
+            renderScope.launch {
+                runCatching {
+                    val renderer = jsonSerializer.decodeFromString(serializer(), data!!)
+                    val nimbusAd = adCache[renderer.auctionId]!!
+                    ad.dynamicPriceAd = DynamicPriceAd(
+                        adController = withContext(Dispatchers.Main) { render(nimbusAd) }.apply {
+                            attachDynamicPriceListener(ad, renderer.clickTracker, renderScope)
+                            publisherListener?.let { listeners.add(it) }
+                        }
+                    )
+                }.onFailure {
+                    withContext(Dispatchers.Main) {
+                        publisherListener?.onError(
+                            NimbusError(
+                                errorType = NimbusError.ErrorType.RENDERER_ERROR,
+                                message = "Failed to render dynamic price ad",
+                                cause = it,
+                            )
+                        )
                     }
                 }
-                onClick()
             }
-            AdEvent.DESTROYED -> onDestroy()
-            else -> return
         }
-    }
 
-    override fun onError(error: NimbusError) {
-        destroy()
+        fun AdController.attachDynamicPriceListener(
+            googleAd: Ad,
+            googleClickTracker: String,
+            coroutineScope: CoroutineScope,
+        ) = listeners.add(object : AdController.Listener {
+
+            val adEventCallback: AdEventCallback?
+                get() = when(googleAd) {
+                    is BannerAd -> googleAd.adEventCallback
+                    is InterstitialAd -> googleAd.adEventCallback
+                    else -> null
+                }
+
+            override fun onAdEvent(adEvent: AdEvent) {
+                when (adEvent) {
+                    AdEvent.CLICKED -> {
+                        coroutineScope.launch(Dispatchers.IO) {
+                            when (OneShotConnection(googleClickTracker).use { it.responseCode }) {
+                                in 200..399 -> log(Log.VERBOSE, "Fired Google click tracker")
+                                else -> log(Log.WARN, "Error firing Google click tracker")
+                            }
+                        }
+                        adEventCallback?.onAdClicked()
+                    }
+                    AdEvent.DESTROYED -> {
+                        googleAd.dynamicPriceAd = null
+                        if (googleAd is InterstitialAd) maybeClearInterstitial()
+                    }
+                    else -> return
+                }
+            }
+
+            override fun onError(error: NimbusError) {
+                destroy()
+            }
+        })
+
+        val adCache = LruCache<String, NimbusAd>(10)
+
+        @OptIn(ExperimentalSerializationApi::class)
+        val jsonSerializer = Json {
+            coerceInputValues = true
+            explicitNulls = false
+            ignoreUnknownKeys = true
+        }
+
+        val renderScope = CoroutineScope(Dispatchers.Default) + CoroutineName("DynamicPrice")
     }
-})
+}
 
 @JvmInline @WorkerThread
 value class OneShotConnection(val connection: HttpURLConnection): AutoCloseable {
-
     constructor(url: String, timeout: Duration = 30.seconds) : this(
         (URL(url).openConnection() as HttpURLConnection).apply {
             connectTimeout = timeout.inWholeMilliseconds.toInt()
@@ -188,35 +229,19 @@ value class OneShotConnection(val connection: HttpURLConnection): AutoCloseable 
 }
 
 /** Renders a Nimbus Ad into the provided ViewGroup */
-suspend inline fun NimbusAd.renderInline(container: ViewGroup): AdController =
-    suspendCancellableCoroutine { continuation ->
-        Renderer.loadAd(this, container, object : Renderer.Listener, NimbusError.Listener {
-            override fun onAdRendered(controller: AdController) {
-                if (continuation.isActive) continuation.resume(controller) else controller.destroy()
+suspend inline fun NimbusAd.renderInline(container: ViewGroup): AdController {
+    return suspendCancellableCoroutine { continuation ->
+        Renderer.loadAd(
+            this, container,
+            object : Renderer.Listener, NimbusError.Listener {
+                override fun onAdRendered(controller: AdController) {
+                    if (continuation.isActive) continuation.resume(controller) else controller.destroy()
+                }
+
+                override fun onError(error: NimbusError) {
+                    if (continuation.isActive) continuation.resumeWithException(error)
+                }
             }
-
-            override fun onError(error: NimbusError) {
-                if (continuation.isActive) continuation.resumeWithException(error)
-            }
-        })
+        )
     }
-
-private fun Activity.destroy() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-        overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
-        finish()
-    } else {
-        finish()
-        @Suppress("DEPRECATION")
-        overridePendingTransition(0, 0)
-    }
-}
-
-internal val nimbusAdCache = LruCache<String, NimbusAd>(10)
-
-@OptIn(ExperimentalSerializationApi::class)
-internal val jsonSerializer = Json {
-    coerceInputValues = true
-    explicitNulls = false
-    ignoreUnknownKeys = true
 }

--- a/dynamicprice/nextgen/src/androidMain/kotlin/DynamicPrice.kt
+++ b/dynamicprice/nextgen/src/androidMain/kotlin/DynamicPrice.kt
@@ -46,8 +46,6 @@ fun <T: BaseAdRequestBuilder<T>> BaseAdRequestBuilder<T>.applyDynamicPrice(
 ) {
     nimbusAdCache.put(nimbusAd.auctionId, nimbusAd)
     nimbusAd.targetingMap(mapping).forEach { putCustomTargeting(it.key, it.value) }
-    // Adds the type parameter since it is missing in the Android SDK
-    putCustomTargeting("na_type", nimbusAd.type())
 }
 
 /**

--- a/dynamicprice/nextgen/src/androidMain/kotlin/Examples.kt
+++ b/dynamicprice/nextgen/src/androidMain/kotlin/Examples.kt
@@ -158,7 +158,7 @@ fun loadRefreshingBanner(
                             eventCallback = eventCallback,
                         )?.apply {
                             bannerAd?.destroy()
-                            container.destroyNimbusAds()
+                            bannerAd?.dynamicPriceAd?.destroy()
                             container.removeAllViews()
                             container.addView(getView(activity))
                         }
@@ -167,7 +167,7 @@ fun loadRefreshingBanner(
             }
         } finally {
             bannerAd?.destroy()
-            container.destroyNimbusAds()
+            bannerAd?.dynamicPriceAd?.destroy()
             container.removeAllViews()
         }
     }

--- a/dynamicprice/nextgen/src/androidMain/kotlin/MainActivity.kt
+++ b/dynamicprice/nextgen/src/androidMain/kotlin/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : ComponentActivity() {
                             handleEventForNimbus(
                                 name = name,
                                 data = data,
-                                eventListener = object : AdController.Listener {
+                                listener = object : AdController.Listener {
                                     override fun onAdEvent(adEvent: AdEvent) {
                                         Log.i("Nimbus Ads", adEvent.name)
                                     }


### PR DESCRIPTION
## Changes

- Removed na_type key included in 2.29.0 from `applyDynamicPrice` method
- Added `activity` parameter to `InterstitialAd.handleEventForNimbus`
- Renamed `eventListener` parameter to `listener` in `handleEventForNimbus`
- Renamed `RenderEvent` to `DynamicPriceRenderer` and changed to regular class implementation
- Moved `adCache` and `jsonSerializer` to `DynamicPriceRenderer` companion object
- Added `DynamicPriceAd` value class for storing Nimbus `AdController` on NextGen `Ad` objects
- Added `na_show` event for showing interstitials
- Removed lifecycle bound destruction of Nimbus ads, developers must now call `Ad.dynamicPriceAd?.destroy()`