### PR TITLE
Update Gradle, Androidx Navigation, Okhttp, Okio, and Nimbus

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs
 
 | Platform                                       | Supported Languages | Latest Version                                                                                                                       |
 |------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.31.0-blue)                                                                        |
+| Android                                        | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.32.0-blue)                                                                        |
 | [iOS](/../../../../adsbynimbus/nimbus-ios-sdk) | Swift               | [![iOS](https://img.shields.io/github/v/release/adsbynimbus/nimbus-ios-sdk)](https://github.com/adsbynimbus/nimbus-ios-sdk/releases) |
 | [Unity](/../../../../adsbynimbus/nimbus-unity) | C#                  | [![OpenRTB](https://img.shields.io/github/v/release/adsbynimbus/nimbus-unity)](https://github.com/adsbynimbus/nimbus-unity/releases) |
 []()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,8 @@ gson = "2.13.1"
 kotlin = "2.2.0"
 kotlin-coroutines = "1.10.2"
 
-okhttp = "4.12.0"
-okio = "3.13.0"
+okhttp = "5.1.0"
+okio = "3.15.0"
 
 slf4j = "2.0.17"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 ads-amazon = "11.0.1"
 ads-google = "24.4.0"
 ads-google-nextgen = "0.17.0-alpha02"
-ads-nimbus = "2.31.0"
+ads-nimbus = "2.32.0"
 
 android = "8.10.1"
 android-jvm = "19"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ android-sdk = "36"
 androidx-appcompat = "1.7.1"
 androidx-collection = "1.5.0"
 androidx-lifecycle = "2.9.1"
-androidx-navigation = "2.9.0"
+androidx-navigation = "2.9.1"
 androidx-startup = "1.2.0"
 
 api-admanager = "5.9.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Updated Libraries

- Androidx Navigation: 2.9.1
- Gradle: 9.0.0-rc-2
- Nimbus: 2.32.0
- OkHttp: 5.1.0
- Okio: 3.15.0