### PR TITLE
Google NextGen 0.18.0-beta01 update

### DIFF
--- a/dynamicprice/nextgen/build.gradle.kts
+++ b/dynamicprice/nextgen/build.gradle.kts
@@ -29,9 +29,15 @@ kotlin {
 
 configurations.configureEach {
     resolutionStrategy.eachDependency {
-        if (requested.module == libs.ads.amazon.get().module) {
-            useVersion("10.1.1")
-            because("11+ will not serve ads due to failed GMA 24+ check")
+        when (requested.module) {
+            libs.ads.amazon.get().module -> {
+                useVersion("10.1.1")
+                because("11+ will not serve ads due to failed GMA 24+ check")
+            }
+            libs.okhttp.get().module -> {
+                useVersion("4.12.0")
+                because("Google Next Gen references a class that does not exist in 5+")
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ads-amazon = "11.0.1"
 ads-google = "24.5.0"
-ads-google-nextgen = "0.17.0-alpha02"
+ads-google-nextgen = "0.18.0-beta01"
 ads-nimbus = "2.33.0"
 
 android = "8.11.1"


### PR DESCRIPTION
## Changes

- Fixed runtime crash caused by Google NextGen incompatibility with OkHttp 5+

## Updated Libraries

- Google NextGen: 0.18.0-beta01