### PR TITLE
Update Gradle 9.1.0, Android Gradle Plugin 8.12.3, Compose 1.9.0, Androidx Lifecycle 2.9.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  XCODE_VERSION: 26.0
+
 jobs:
   gradle:
     runs-on: macos-latest
@@ -22,14 +25,14 @@ jobs:
       ORG_GRADLE_PROJECT_openrtbPassword: ${{ github.token }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Xcode
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+        run: sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '24'
+          java-version: '25'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
@@ -50,7 +53,6 @@ jobs:
     env:
       IOS_TARGET: 18.5
       SIMULATOR_NAME: iPhone 16
-      XCODE_VERSION: 26.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ i.e. or passed via the command line.
 #### gradle.properties
 ```properties
 # Override the Android Gradle Plugin to a canary version
-android.gradle=8.13.0-alpha03
+android.gradle=9.0.0-alpha05
 # Override the bytecode used to build the project
 android.jvm=17
 ```
 #### CLI
 ```shell
-./gradlew build -Dandroid.gradle=8.13.0-alpha03 -Dandroid.jvm=17
+./gradlew build -Dandroid.gradle=9.0.0-alpha05 -Dandroid.jvm=17
 ```

--- a/dynamicprice/nextgen/sdk/build.gradle.kts
+++ b/dynamicprice/nextgen/sdk/build.gradle.kts
@@ -27,8 +27,7 @@ kotlin {
 
         compilations.configureEach {
             compileTaskProvider.configure {
-                // Casting works around a type issue with AGP 8.10.0 that is fixed in 8.12.0
-                (compilerOptions as KotlinJvmCompilerOptions).jvmTarget = JvmTarget.JVM_1_8
+                compilerOptions.jvmTarget = JvmTarget.JVM_1_8
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ ads-google = "24.6.0"
 ads-google-nextgen = "0.19.0-beta01"
 ads-nimbus = "2.33.2"
 
-android = "8.11.2"
+android = "8.12.3"
 android-jvm = "19"
 android-min = "26"
 android-sdk = "36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ android-sdk = "36"
 androidx-appcompat = "1.7.1"
 androidx-collection = "1.5.0"
 androidx-core = "1.17.0"
-androidx-lifecycle = "2.9.3"
+androidx-lifecycle = "2.9.4"
 androidx-navigation = "2.9.4"
 androidx-startup = "1.2.0"
 
@@ -22,7 +22,7 @@ api-google-client = "2.8.1"
 
 compose = "1.9.1"
 compose-activity = "1.11.0"
-compose-multiplatform = "1.9.0-rc02"
+compose-multiplatform = "1.9.0"
 
 commons-beanutils = "1.11.0"
 commmons-lang3 = "3.18.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -114,7 +114,6 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -172,7 +171,6 @@ fi
 # For Cygwin or MSYS, switch paths to Windows format before running java
 if "$cygwin" || "$msys" ; then
     APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
-    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
 
     JAVACMD=$( cygpath --unix "$JAVACMD" )
 
@@ -212,7 +210,6 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
-        -classpath "$CLASSPATH" \
         -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -70,11 +70,10 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/sdk-extensions/android/admob/build.gradle.kts
+++ b/sdk-extensions/android/admob/build.gradle.kts
@@ -25,8 +25,7 @@ kotlin {
         minSdk = 21
         compilations.configureEach {
             compileTaskProvider.configure {
-                // Casting works around a type issue with AGP 8.10.0 that is fixed in 8.12.0
-                (compilerOptions as KotlinJvmCompilerOptions).jvmTarget = JvmTarget.JVM_1_8
+                compilerOptions.jvmTarget = JvmTarget.JVM_1_8
             }
         }
 


### PR DESCRIPTION
## Changes

- Github Actions gradle build now uses Java 25
- Updated Github Actions versions to latest

## Updated Libraries

- Android Gradle Plugin: 8.12.3
- Androidx Lifecycle: 2.9.4
- Compose Multiplatform: 1.9.0
- Gradle: 9.1.0