### PR TITLE
Google Nextgen 1.0.1 update and build cleanup

### DIFF
--- a/dynamicprice/nextgen/build.gradle.kts
+++ b/dynamicprice/nextgen/build.gradle.kts
@@ -76,15 +76,9 @@ dependencies {
 
 configurations.configureEach {
     resolutionStrategy.eachDependency {
-        when (requested.module) {
-            libs.ads.amazon.get().module -> {
-                useVersion("10.1.1")
-                because("11+ will not serve ads due to failed GMA 24+ check")
-            }
-            libs.okhttp.get().module -> {
-                useVersion("4.12.0")
-                because("Google Next Gen references a class that does not exist in 5+")
-            }
+        if (requested.module == libs.ads.amazon.get().module) {
+            useVersion("10.1.1")
+            because("11+ will not serve ads due to failed GMA 24+ check")
         }
     }
 }

--- a/dynamicprice/nextgen/sdk/build.gradle.kts
+++ b/dynamicprice/nextgen/sdk/build.gradle.kts
@@ -77,12 +77,6 @@ dependencies.constraints {
             because("BundleCompat.getSerializable added in 1.13.0")
         }
     }
-    androidMainImplementation(libs.okio) {
-        version {
-            require("[3.4.0,)")
-            because("Addresses CVE-2023-3635 reported on Okio 3.2.0")
-        }
-    }
     androidMainImplementation(libs.cronet.fallback) {
         version {
             require("143.7445.0")

--- a/dynamicprice/nextgen/sdk/build.gradle.kts
+++ b/dynamicprice/nextgen/sdk/build.gradle.kts
@@ -77,12 +77,6 @@ dependencies.constraints {
             because("BundleCompat.getSerializable added in 1.13.0")
         }
     }
-    androidMainImplementation(libs.cronet.fallback) {
-        version {
-            require("143.7445.0")
-            because("141.7340.3 causes a build error with duplicate namespaces")
-        }
-    }
 }
 
 dokka {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ads-amazon = "11.2.1"
 ads-google = "25.2.0"
-ads-google-nextgen = "1.0.0"
+ads-google-nextgen = "1.0.1"
 ads-nimbus = "2.36.1"
 
 android = "9.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,7 +92,6 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
 compose-ui-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-multiplatform" }
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-multiplatform" }
-cronet-fallback = { module = "org.chromium.net:cronet-fallback" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 iabtcf = { module = "com.iabtcf:iabtcf-decoder", version.ref = "iabtcf" }
 jackson = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }

--- a/sdk-extensions/android/admob-nextgen/build.gradle.kts
+++ b/sdk-extensions/android/admob-nextgen/build.gradle.kts
@@ -79,6 +79,10 @@ kotlin {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    // Revisit this when updating mockk where this warning originates from
+    if (JavaVersion.current() >= JavaVersion.VERSION_24) {
+        jvmArgs("--sun-misc-unsafe-memory-access=allow")
+    }
 }
 
 dokka {

--- a/sdk-extensions/android/admob-nextgen/build.gradle.kts
+++ b/sdk-extensions/android/admob-nextgen/build.gradle.kts
@@ -81,15 +81,6 @@ tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 
-dependencies.constraints {
-    androidMainImplementation(libs.okio) {
-        version {
-            require("[3.4.0,)")
-            because("Addresses CVE-2023-3635 reported on Okio 3.2.0")
-        }
-    }
-}
-
 dokka {
     moduleName = "AdMob NextGen"
     dokkaGeneratorIsolation = ClassLoaderIsolation()


### PR DESCRIPTION
## Changes
- Updated Google Nextgen to 1.0.1
- Removed unnecessary dependency constraints with Google Nextgen 1.0 and Nimbus 2.36.1 updates
- Suppressed warning from mockk when testing with JDK 24+