### PR TITLE
Kotlin Coroutines 1.11.0, dependabot rules update, and build cleanup

### DIFF
--- a/.github/actions/xcodebuild/action.yml
+++ b/.github/actions/xcodebuild/action.yml
@@ -16,7 +16,7 @@ inputs:
   version:
     description: 'xcode version'
     required: false
-    default: '26.3'
+    default: '26.4.1'
 runs:
   using: "composite"
   steps:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
     registries: "*"
     schedule:
       interval: "weekly"
+    groups:
       build:
         patterns:
           - "com.android.library"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ registries:
     username: ${{ secrets.USER }}
     password: ${{ secrets.GHP }}
 
+multi-ecosystem-groups:
+  ads:
+    target-branch: "ads/update"
+    schedule:
+      interval: "daily"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -16,17 +22,13 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     registries: "*"
-    schedule:
-      interval: "daily"
-    target-branch: "ads/update"
-    groups:
-      ads:
-        patterns:
-          - "com.adsbynimbus*"
-          - "com.amazon*"
-          - "*play-services-ads"
-          - "*ads-mobile-sdk"
-          - "com.iabtcf*"
+    multi-ecosystem-group: "ads"
+    patterns:
+      - "com.adsbynimbus*"
+      - "com.amazon*"
+      - "*play-services-ads"
+      - "*ads-mobile-sdk"
+      - "com.iabtcf*"
 
   - package-ecosystem: "gradle"
     directory: "/"
@@ -53,9 +55,8 @@ updates:
       libs:
         patterns:
           - "*"
-          -
+
   - package-ecosystem: "swift"
     directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "ads/update"
+    multi-ecosystem-group: "ads"
+    patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     registries: "*"
     schedule:
       interval: "daily"
+    target-branch: "ads/update"
     groups:
       ads:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,29 +26,28 @@ updates:
           - "*play-services-ads"
           - "*ads-mobile-sdk"
           - "com.iabtcf*"
-# Only update Android Gradle Plugin patches to maintain compatibility with JetBrains IDEA
-      android-gradle:
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries: "*"
+    schedule:
+      interval: "weekly"
+      build:
         patterns:
-          - "com.android.*"
-        update-types:
-          - "patch"
-      compose:
+          - "com.android.library"
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.dokka"
+          - "com.google.devtools.ksp"
+      app:
         patterns:
           - "org.jetbrains.compose*"
-          - "androidx.compose*"
-          - "*compose"
-      androidx:
-        patterns:
           - "androidx.*"
-      kotlin:
+          - "*compose"
+      test:
         patterns:
           - "org.jetbrains.*"
           - "io.kotest*"
           - "io.mockk*"
-          - "com.google.devtools.ksp"
-      other:
+      libs:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "com.android.*"
-        update-types: [ "version-update:semver-minor", "version-update:semver-major" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,9 @@ updates:
       libs:
         patterns:
           - "*"
+          -
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "ads/update"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,9 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-read-only: true
           kotlin-version: ${{ vars.CODEQL_KOTLIN }}
+      - name: Setup Swift
+        if: matrix.language == 'swift'
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "solutions",
     platforms: [.iOS(.v16)],
     dependencies: [
-        .package(url: "https://github.com/adsbynimbus/nimbus-ios-sdk", exact: "2.32.1"),
+        .package(url: "https://github.com/adsbynimbus/nimbus-ios-sdk", exact: "2.34.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -2,31 +2,27 @@
 [![CodeQL Analysis](https://github.com/adsbynimbus/solutions/actions/workflows/codeql.yml/badge.svg)](https://github.com/adsbynimbus/solutions/actions/workflows/codeql.yml)
 
 # Nimbus Solutions Engineering
-
 Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs/](https://docs.adsbynimbus.com/docs/)
 
 | Platform                                             | Supported Languages | Latest Version                                                                                                                       |
 |------------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Android                                              | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.36.0-blue)                                                                        |
+| Android                                              | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.36.1-blue)                                                                        |
 | [iOS](https://github.com/adsbynimbus/nimbus-ios-sdk) | Swift               | [![iOS](https://img.shields.io/github/v/release/adsbynimbus/nimbus-ios-sdk)](https://github.com/adsbynimbus/nimbus-ios-sdk/releases) |
 | [Unity](https://github.com/adsbynimbus/nimbus-unity) | C#                  | [![Unity](https://img.shields.io/github/v/release/adsbynimbus/nimbus-unity)](https://github.com/adsbynimbus/nimbus-unity/releases)   |
 
 []()
 
 ## Build / IDE Setup
-
 Android Studio Panda 4 `2025.3.4` or newer with the
 latest [Kotlin Multiplatform Plugin](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-plugin-releases.html#release-details)
 is recommended.
 
 ### Overriding Tooling
-
 The Android Gradle Plugin and JVM Target can be overridden using the properties `android.gradle`
 and `android.jvm` which can be defined in a `gradle.properties` file in the Gradle User Home directory
 or passed via the command line.
 
 #### gradle.properties
-
 ```properties
 # Override the Android Gradle Plugin to a canary version
 android.gradle=9.3.0-alpha01
@@ -35,7 +31,6 @@ android.jvm=21
 ```
 
 #### CLI
-
 ```shell
-./gradlew build -Dandroid.gradle=9.0.0 -Dandroid.jvm=21
+./gradlew build -Dandroid.gradle=9.3.0-alpha01 -Dandroid.jvm=21
 ```

--- a/compose/android/build.gradle.kts
+++ b/compose/android/build.gradle.kts
@@ -28,6 +28,7 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = !codeQL.isPresent
+            isShrinkResources = !codeQL.isPresent
         }
     }
 

--- a/dynamicprice/android/build.gradle.kts
+++ b/dynamicprice/android/build.gradle.kts
@@ -34,10 +34,8 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = !codeQL.isPresent
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                layout.settingsDirectory.file("r8-optimization-rules.pro"),
-            )
+            isShrinkResources = !codeQL.isPresent
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }
 

--- a/dynamicprice/nextgen/build.gradle.kts
+++ b/dynamicprice/nextgen/build.gradle.kts
@@ -36,10 +36,8 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = !codeQL.isPresent
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                layout.settingsDirectory.file("r8-optimization-rules.pro"),
-            )
+            isShrinkResources = !codeQL.isPresent
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }
 

--- a/dynamicprice/nextgen/sdk/build.gradle.kts
+++ b/dynamicprice/nextgen/sdk/build.gradle.kts
@@ -46,12 +46,6 @@ kotlin {
             artifact(dokkaJavadocJar)
             artifact(dokkaHtmlJar)
         }
-
-        @Suppress("UnstableApiUsage")
-        optimization {
-            consumerKeepRules.publish = true
-            consumerKeepRules.file(layout.settingsDirectory.file("r8-optimization-rules.pro"))
-        }
     }
 
     compilerOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ jackson = "2.21.3"
 
 kotest = "6.1.11"
 kotlin = "2.3.21"
-kotlin-coroutines = "1.10.2"
+kotlin-coroutines = "1.11.0"
 ksp = "2.3.7"
 mockk = "1.14.9"
 

--- a/omsdk/android/build.gradle.kts
+++ b/omsdk/android/build.gradle.kts
@@ -31,10 +31,8 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = !codeQL.isPresent
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                layout.settingsDirectory.file("r8-optimization-rules.pro"),
-            )
+            isShrinkResources = !codeQL.isPresent
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }
 

--- a/r8-optimization-rules.pro
+++ b/r8-optimization-rules.pro
@@ -1,1 +1,0 @@
--dontwarn com.amazon.privacypass.**

--- a/sdk-extensions/android/admob-nextgen/build.gradle.kts
+++ b/sdk-extensions/android/admob-nextgen/build.gradle.kts
@@ -47,12 +47,6 @@ kotlin {
             artifact(dokkaHtmlJar)
         }
 
-        @Suppress("UnstableApiUsage")
-        optimization {
-            consumerKeepRules.publish = true
-            consumerKeepRules.file(layout.settingsDirectory.file("r8-optimization-rules.pro"))
-        }
-
         withHostTest { }
     }
 

--- a/sdk-extensions/android/admob/build.gradle.kts
+++ b/sdk-extensions/android/admob/build.gradle.kts
@@ -44,12 +44,6 @@ kotlin {
             artifact(dokkaJavadocJar)
             artifact(dokkaHtmlJar)
         }
-
-        @Suppress("UnstableApiUsage")
-        optimization {
-            consumerKeepRules.publish = true
-            consumerKeepRules.file(layout.settingsDirectory.file("r8-optimization-rules.pro"))
-        }
     }
 
     compilerOptions {


### PR DESCRIPTION
## Changes
- Updated dependabot to run weekly for all libs except ads
- Added Swift dependabot configuration with multi-ecosystem daily ad updates
- Updated CI Xcode version to 26.4.1 and Swift to 6.3
- Removed r8 rules which are no longer required as of Nimbus Android 2.36.1
- Enabled Android resource shrinking
- Updated README

## Updated Libraries
- Kotlin Coroutines: 1.11.0
- Nimbus iOS: 2.34.0