### PR TITLE
Dynamic Price Next Gen RewardedAd fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official Nimbus documentation can be found at [https://docs.adsbynimbus.com/docs
 
 | Platform                                             | Supported Languages | Latest Version                                                                                                                       |
 |------------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Android                                              | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.36.1-blue)                                                                        |
+| Android                                              | Java, Kotlin        | ![Android](https://img.shields.io/badge/release-v2.37.0-blue)                                                                        |
 | [iOS](https://github.com/adsbynimbus/nimbus-ios-sdk) | Swift               | [![iOS](https://img.shields.io/github/v/release/adsbynimbus/nimbus-ios-sdk)](https://github.com/adsbynimbus/nimbus-ios-sdk/releases) |
 | [Unity](https://github.com/adsbynimbus/nimbus-unity) | C#                  | [![Unity](https://img.shields.io/github/v/release/adsbynimbus/nimbus-unity)](https://github.com/adsbynimbus/nimbus-unity/releases)   |
 

--- a/dynamicprice/nextgen/sdk/README.md
+++ b/dynamicprice/nextgen/sdk/README.md
@@ -83,6 +83,6 @@ Add the `com.adsbynimbus.dynamicprice:nextgen` module to you application or libr
 
 ```kotlin
 dependencies {
-    implementation("com.adsbynimbus.dynamicprice:nextgen:0.22.0")
+    implementation("com.adsbynimbus.dynamicprice:nextgen:+")
 }
 ```

--- a/dynamicprice/nextgen/sdk/src/androidMain/kotlin/internal/DynamicPriceRewarded.kt
+++ b/dynamicprice/nextgen/sdk/src/androidMain/kotlin/internal/DynamicPriceRewarded.kt
@@ -18,8 +18,6 @@ internal class DynamicPriceRewardedAd(
     val listener: AdController.Listener?
 ) : RewardedAd by googleAd, AdController.Listener {
 
-    var rewardListener: OnUserEarnedRewardListener? = null
-
     fun Context.createController(): AdController? = loadBlockingAd(nimbusAd)?.apply {
         googleAd.dynamicPriceAd = DynamicPriceAd(adController = this)
         listeners.add(this@DynamicPriceRewardedAd)
@@ -30,14 +28,14 @@ internal class DynamicPriceRewardedAd(
         if (googleAd.isNimbusWin) application.createController()
     }
 
+    var rewardListener: OnUserEarnedRewardListener? = null
+    var shown: Boolean = false
+
     override fun show(activity: Activity, onUserEarnedRewardListener: OnUserEarnedRewardListener) {
         if (!googleAd.isNimbusWin) googleAd.show(activity, onUserEarnedRewardListener) else {
             (googleAd.dynamicPriceAd?.adController ?: activity.createController())?.run {
                 rewardListener = onUserEarnedRewardListener
-                googleAd.show(activity) { }
-                @Suppress("DEPRECATION")
-                activity.overridePendingTransition(0, 0)
-                Platform.doOnNextActivity { start() }
+                start()
             } ?: googleAd.adEventCallback?.onAdFailedToShowFullScreenContent(
                 FullScreenContentError(
                     code = MEDIATION_SHOW_ERROR,
@@ -51,15 +49,22 @@ internal class DynamicPriceRewardedAd(
         googleAd.dynamicPriceAd?.destroy()
         googleAd.dynamicPriceAd = null
         rewardListener = null
-        DynamicPriceRenderer.maybeClearInterstitial()
         googleAd.destroy()
     }
 
     override fun onAdEvent(adEvent: AdEvent) {
         when (adEvent) {
-            AdEvent.CLICKED -> googleAd.adEventCallback?.onAdClicked()
+            AdEvent.IMPRESSION -> {
+                shown = true
+                adEventCallback?.onAdShowedFullScreenContent()
+                adEventCallback?.onAdImpression()
+            }
+            AdEvent.CLICKED -> adEventCallback?.onAdClicked()
             AdEvent.COMPLETED -> rewardListener?.onUserEarnedReward(googleAd.getRewardItem())
-            AdEvent.DESTROYED -> destroy()
+            AdEvent.DESTROYED -> {
+                if (shown) adEventCallback?.onAdDismissedFullScreenContent()
+                destroy()
+            }
             else -> return
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ ads-amazon = "11.3.0"
 ads-google = "25.3.0"
 ads-google-ima = "3.39.0"
 ads-google-nextgen = "1.1.1"
-ads-nimbus = "2.36.1"
+ads-nimbus = "2.37.0"
 
 android = "9.2.1"
 android-jvm = "19"


### PR DESCRIPTION
## Changes
- Dynamic Price Next Gen RewardedAd will no longer show the Google ad first due to a threading issue with Meta
- Added proxy for adEventCallback to receive notifications from Nimbus AdController

## Updated Libraries
- Nimbus Android: 2.37.0