### PR TITLE
Update Gradle, Cache / Checkout Actions, Jackson, and Kotest 

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -48,7 +48,7 @@ runs:
       run: rm -rf ~/.konan
       shell: bash
     - name: Restore Kotlin Native
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       id: kotlin-cache
       with:
         path: ~/.konan

--- a/.github/actions/xcodebuild/action.yml
+++ b/.github/actions/xcodebuild/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
     - name: Build Cache
       id: build-cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: |
           ~/Library/Developer/Xcode/DerivedData

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Xcode
         id: xcodebuild
         uses: ./.github/actions/xcodebuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew build
         shell: bash
       - name: Cache Kotlin Native
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         if: ${{ github.ref == 'refs/heads/main' && steps.gradle.outcome.kotlin-cache-hit != 'true' }}
         with:
           path: ~/.konan
@@ -63,7 +63,7 @@ jobs:
           xcodebuild test-without-building -disableAutomaticPackageResolution ${{ steps.xcodebuild.outputs.options }}
         shell: bash
       - name: Cache DerivedData
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         if: ${{ github.ref == 'refs/heads/main' && steps.xcodebuild.outcome.build-cache-hit != 'true' }}
         with:
           path: |

--- a/dynamicprice/nextgen/sdk/build.gradle.kts
+++ b/dynamicprice/nextgen/sdk/build.gradle.kts
@@ -11,14 +11,14 @@ plugins {
 
 val codeQL = providers.provider { extra.properties["codeQL"] }
 
-val dokkaJavadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
+val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
+    archiveClassifier = "javadoc"
     description = "Creates a javadoc jar for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
 }
 
-val dokkaHtmlJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("html-doc")
+val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
+    archiveClassifier = "html-doc"
     description = "Creates a jar containing html docs for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
 }

--- a/gam-direct/android/instream/build.gradle.kts
+++ b/gam-direct/android/instream/build.gradle.kts
@@ -10,15 +10,15 @@ plugins {
 
 val codeQL = providers.provider { extra.properties["codeQL"] }
 
-val dokkaJavadocJar by tasks.registering(Jar::class) {
-    description = "Creates a javadoc jar using Dokka"
-    archiveClassifier.set("javadoc")
+val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
+    archiveClassifier = "javadoc"
+    description = "Creates a javadoc jar for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
 }
 
-val dokkaHtmlJar by tasks.registering(Jar::class) {
-    description = "Creates a HTML documentation jar using Dokka"
-    archiveClassifier.set("html-doc")
+val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
+    archiveClassifier = "html-doc"
+    description = "Creates a jar containing html docs for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ gson = "2.14.0"
 iabtcf = "2.0.10"
 jackson = "2.22.0"
 
-kotest = "6.2.0"
+kotest = "6.2.1"
 kotlin = "2.4.0"
 kotlin-coroutines = "1.11.0"
 ksp = "2.3.9"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/sdk-extensions/android/admob-nextgen/build.gradle.kts
+++ b/sdk-extensions/android/admob-nextgen/build.gradle.kts
@@ -12,14 +12,14 @@ plugins {
 
 val codeQL = providers.provider { extra.properties["codeQL"] }
 
-val dokkaJavadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
+val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
+    archiveClassifier = "javadoc"
     description = "Creates a javadoc jar for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
 }
 
-val dokkaHtmlJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("html-doc")
+val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
+    archiveClassifier = "html-doc"
     description = "Creates a jar containing html docs for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
 }

--- a/sdk-extensions/android/admob/build.gradle.kts
+++ b/sdk-extensions/android/admob/build.gradle.kts
@@ -10,14 +10,14 @@ plugins {
 
 val codeQL = providers.provider { extra.properties["codeQL"] }
 
-val dokkaJavadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
+val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
+    archiveClassifier = "javadoc"
     description = "Creates a javadoc jar for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
 }
 
-val dokkaHtmlJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("html-doc")
+val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
+    archiveClassifier = "html-doc"
     description = "Creates a jar containing html docs for bundling with an Android Library"
     from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,6 +58,17 @@ dependencyResolutionManagement {
     }
 }
 
+gradle.beforeProject {
+    buildscript.configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "com.fasterxml.jackson.core") {
+                useVersion(if (requested.module.name == "jackson-annotations") "2.22" else "2.22.0")
+                because("Fixes CWE-918 (SSRF)")
+            }
+        }
+    }
+}
+
 rootProject.name = "nimbus-solutions"
 
 include(":compose:android")


### PR DESCRIPTION
## Changes
- Update checkout action to v7 missed in `build.yml`
- Update cache action to v6
- Update Jackson to 2.22.0 to fix [CWE-918](https://github.com/adsbynimbus/solutions/security/dependabot/38)
- Replaced Dokka task registration with `tasks.register` to fix Gradle deprecations

## Updated Libraries
- Gradle: 9.6.1
- Jackson: 2.22.0
- Kotest: 6.2.1