### PR TITLE
Update Kotlin to 2.4.10 and other lib updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ gson = "2.14.0"
 iabtcf = "2.0.10"
 jackson = "2.22.1"
 
-kotest = "6.2.1"
+kotest = "6.2.2"
 kotlin = "2.4.10"
 kotlin-coroutines = "1.11.0"
 ksp = "2.3.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ iabtcf = "2.0.10"
 jackson = "2.22.0"
 
 kotest = "6.2.1"
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 kotlin-coroutines = "1.11.0"
 ksp = "2.3.9"
 mockk = "1.14.11"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ androidx-navigation = "2.9.8"
 androidx-startup = "1.2.0"
 
 api-admanager = "5.13.0"
-api-google-auth = "1.48.0"
+api-google-auth = "1.49.0"
 api-google-client = "2.9.0"
 
 compose-multiplatform = "1.11.1"
@@ -35,7 +35,7 @@ commmons-lang3 = "3.20.0"
 dokka = "2.2.0"
 gson = "2.14.0"
 iabtcf = "2.0.10"
-jackson = "2.22.0"
+jackson = "2.22.1"
 
 kotest = "6.2.1"
 kotlin = "2.4.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ jackson = "2.22.0"
 kotest = "6.2.1"
 kotlin = "2.4.10"
 kotlin-coroutines = "1.11.0"
-ksp = "2.3.9"
+ksp = "2.3.10"
 mockk = "1.14.11"
 
 okhttp = "5.4.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,7 +62,7 @@ gradle.beforeProject {
     buildscript.configurations.configureEach {
         resolutionStrategy.eachDependency {
             if (requested.group == "com.fasterxml.jackson.core") {
-                useVersion(if (requested.module.name == "jackson-annotations") "2.22" else "2.22.0")
+                useVersion(if (requested.module.name == "jackson-annotations") "2.22" else "2.22.1")
                 because("Fixes CWE-918 (SSRF)")
             }
         }


### PR DESCRIPTION
## Updated Libraries
- Google Auth: 1.49.0
- Jackson: 2.22.1
- Kotest: 6.2.2
- Kotlin 2.4.10
- Ksp: 2.3.10