### PR TITLE
Build Maintenance to fix Security Warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,8 +28,8 @@ api-admanager = "5.13.0"
 api-google-auth = "1.50.0"
 api-google-client = "2.9.0"
 
-compose-multiplatform = "1.11.1"
-compose-multiplatform-material3 = "1.11.0-alpha07"
+compose-multiplatform = "1.12.0-rc01"
+compose-multiplatform-material3 = "1.12.0-alpha03"
 
 commons-beanutils = "1.11.0"
 commmons-lang3 = "3.20.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ iabtcf = "2.0.10"
 jackson = "2.22.1"
 
 kotest = "6.2.4"
-kotlin = "2.4.10"
+kotlin = "2.4.20-RC"
 kotlin-coroutines = "1.11.0"
 ksp = "2.3.11"
 mockk = "1.14.11"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,9 +12,9 @@ android-jvm = "19"
 android-min = "26"
 android-sdk = "37"
 
-androidx-appcompat = "1.7.1"
+androidx-appcompat = "1.8.0"
 androidx-collection = "1.6.0"
-androidx-compose = "1.11.4"
+androidx-compose = "1.12.0"
 androidx-compose-activity = "1.13.0"
 androidx-compose-icons = "1.7.8"
 androidx-compose-material3 = "1.4.0"
@@ -39,7 +39,7 @@ gson = "2.14.0"
 iabtcf = "2.0.10"
 jackson = "2.22.1"
 
-kotest = "6.2.3"
+kotest = "6.2.4"
 kotlin = "2.4.10"
 kotlin-coroutines = "1.11.0"
 ksp = "2.3.11"
@@ -114,7 +114,12 @@ okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 slf4j = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 
 [bundles]
-androidx = ["androidx-collection", "androidx-lifecycle", "androidx-startup"]
+androidx = [
+    "androidx-collection",
+    "androidx-core",
+    "androidx-lifecycle",
+    "androidx-startup",
+]
 androidx-compose = [
     "androidx-compose-activity",
     "androidx-compose-icons-core",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -73,6 +73,10 @@ gradle.lifecycle.beforeProject {
                         useVersion(if (requested.module.name == "jackson-annotations") "2.22" else "2.22.1")
                         because("Fixes CWE-918 (SSRF)")
                     }
+                    "io.opentelemetry" -> {
+                        useVersion("1.65.0")
+                        because("Fixes CVE-2026-45292")
+                    }
                 }
             }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,6 @@ val androidGradleOverride = providers.gradleProperty("android.gradle").filter {
 }
 val androidJvmOverride = providers.gradleProperty("android.jvm")
 val kotlinOverride = providers.gradleProperty("kotlin.gradle")
-val codeQL = providers.environmentVariablesPrefixedBy("CODEQL").map { it.any() }
 
 dependencyResolutionManagement {
     repositories {
@@ -61,16 +60,24 @@ dependencyResolutionManagement {
     }
 }
 
-gradle.beforeProject {
-    buildscript.configurations.configureEach {
-        resolutionStrategy.eachDependency {
-            if (requested.group == "com.fasterxml.jackson.core") {
-                useVersion(if (requested.module.name == "jackson-annotations") "2.22" else "2.22.1")
-                because("Fixes CWE-918 (SSRF)")
+gradle.lifecycle.beforeProject {
+    arrayOf(buildscript.configurations, configurations).forEach {
+        it.configureEach {
+            resolutionStrategy.eachDependency {
+                when (requested.module.group) {
+                    "org.jsoup" -> {
+                        useVersion("1.23.1")
+                        because("Fixes CWE-79")
+                    }
+                    "com.fasterxml.jackson", "com.fasterxml.jackson.core" -> {
+                        useVersion(if (requested.module.name == "jackson-annotations") "2.22" else "2.22.1")
+                        because("Fixes CWE-918 (SSRF)")
+                    }
+                }
             }
         }
     }
-    if (codeQL.get()) {
+    if (providers.environmentVariablesPrefixedBy("CODEQL").map { it.any() }.get()) {
         tasks.withType<JavaCompile>().configureEach {
             outputs.upToDateWhen { false }
         }


### PR DESCRIPTION
## Changes
- Updated resolutionStrategy to use `gradle.lifecycle.beforeProject`
- Update Kotlin, Jackson, Jsoup, and OpenTelementry libraries to fix security warnings
- Add Androidx Core to the `androidx` bundle

## Updated Libraries
- Androidx AppCompat: 1.8.0
- Androidx Compose: 1.12.0
- Compose Mulitplatform: 1.12.0-rc01
- Compose Material3: 1.12.0-alpha03
- Kotest: 6.2.4
- Kotlin: 2.4.20-RC